### PR TITLE
Fix broken getSourceAsArray() function

### DIFF
--- a/code/DropdownImageField.php
+++ b/code/DropdownImageField.php
@@ -86,4 +86,24 @@ class DropdownImageField extends DropdownField {
 	public function getSource() {
             return $this->source;
 	}
+    
+	/**
+	 * Get the source of this field as an array
+	 * Transform the source DataList to an key => value array
+	 *
+	 * @return array
+	 */
+	public function getSourceAsArray()
+	{
+		$source = $this->getSource();
+		if (is_array($source)) {
+			return $source;
+		} else {
+			$sourceArray = array();
+			foreach ($source as $object) {
+				$sourceArray[$object->{$this->keyField}] = $object->{$this->labelField};
+			}
+		}
+		return $sourceArray;
+	}
 }


### PR DESCRIPTION
Fixed `getSourceAsArray()` to return proper array with key => value pairs from the source DataList, using the $keyField as key and $labelField as value.

fixes issue Copperis/DropdownImageField#6
